### PR TITLE
Add pkg-config pc into build system

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4,3 +4,6 @@ SUBDIRS = src
 EXTRA_DIST = 
 
 dist_pkgdata_DATA = README LICENSE.TXT
+
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = libdtcmp.pc

--- a/configure.ac
+++ b/configure.ac
@@ -59,6 +59,7 @@ AC_C_BIGENDIAN
 AC_CONFIG_FILES([ \
   Makefile \
   src/Makefile \
+  libdtcmp.pc \
 ])
 AC_OUTPUT
 

--- a/libdtcmp.pc.in
+++ b/libdtcmp.pc.in
@@ -1,0 +1,12 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: @PACKAGE_NAME@
+Description: Data type comparison library
+Version: @PACKAGE_VERSION@
+URL: @PACKAGE_URL@
+Libs: -L${libdir} -ldtcmp
+Cflags: -I${includedir}/
+


### PR DESCRIPTION
The change set include pc template for libdtcmp, this will install libdtcmp.pc during the installation to make it easy for third-party to locate and use.
