### PR TITLE
Fix m4 macro to detect lwgrp location

### DIFF
--- a/m4/x_ac_lwgrp.m4
+++ b/m4/x_ac_lwgrp.m4
@@ -47,10 +47,10 @@ AC_DEFUN([X_AC_LWGRP], [
     if test "$with_lwgrp" = check || \
        test "x$_x_ac_lwgrp_dirs" = xyes || \
        test "x$_x_ac_lwgrp_dirs" = "x" ; then
-#      AC_CHECK_LIB([lwgrp], [GCS_Comm_split])
+       AC_CHECK_LIB([lwgrp], [lwgrp_comm_free])
 
       # if we found it, set the build flags
-      if test "$ac_cv_lib_lwgrp_GCS_Comm_split" = yes; then
+      if test "$ac_cv_lib_lwgrp_lwgrp_comm_free" = yes; then
         found=yes
         LWGRP_CFLAGS=""
         LWGRP_LDFLAGS=""


### PR DESCRIPTION
A commented out AC_CHECK_LIB() is looking for GCS_Comm_split to
discover the location of lwgrp when uncommented.  This symbol doesn't
appear to exist in lwgrp, so change it to lwgrp_comm_free.

This change, along with specifying `CC=mpicc` on the `configure` command
line makes the library discoverable by `configure`.

Fixes: #6 
Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>