### PR TITLE
disable MPI_LONG_DOUBLE for Cray MPI

### DIFF
--- a/src/dtcmp.c
+++ b/src/dtcmp.c
@@ -314,6 +314,15 @@ int DTCMP_Init(void)
     DTCMP_Op_create(MPI_DOUBLE, dtcmp_op_fn_double_descend, &DTCMP_OP_DOUBLE_DESCEND);
     DTCMP_Op_create(MPI_LONG_DOUBLE, dtcmp_op_fn_longdouble_ascend,  &DTCMP_OP_LONGDOUBLE_ASCEND);
     DTCMP_Op_create(MPI_LONG_DOUBLE, dtcmp_op_fn_longdouble_descend, &DTCMP_OP_LONGDOUBLE_DESCEND);
+
+    /* Work around for unsupported MPI_LONG_DOUBLE in Cray MPI.
+     * The compile time symbol is defined, but it is set to MPI_DATATYPE_NULL in mpi.h:
+     *   #define MPI_LONG_DOUBLE    ((MPI_Datatype)MPI_DATATYPE_NULL)
+     * Without this work around, DTCMP compiles but one gets null datatype errors at runtime. */
+    if (MPI_LONG_DOUBLE != MPI_DATATYPE_NULL) {
+      DTCMP_Op_create(MPI_LONG_DOUBLE, dtcmp_op_fn_longdouble_ascend,  &DTCMP_OP_LONGDOUBLE_ASCEND);
+      DTCMP_Op_create(MPI_LONG_DOUBLE, dtcmp_op_fn_longdouble_descend, &DTCMP_OP_LONGDOUBLE_DESCEND);
+    }
   }
 
   return DTCMP_SUCCESS;


### PR DESCRIPTION
Cray MPI does not support MPI_LONG_DOUBLE.  It is defined at compile time, but it is hard-coded to be MPI_DATATYPE_NULL.  One then gets fatal null datatype errors at runtime.
```
MPICH Notice [Rank 0] [job id 71342.12] [Wed Feb  2 20:38:39 2022] [host129] - Abort(470445571) (rank 0 in comm 0): Fatal error in PMPI_Type_get_extent: Invalid datatype, error stack:
PMPI_Type_get_extent(117): MPI_Type_get_extent(MPI_DATATYPE_NULL, lb=0x7ffe0e1a7780, extent=0x7ffe0e1a7778) failed
PMPI_Type_get_extent(73).: Datatype for argument datatype is a null datatype
```
This disables use of MPI_LONG_DOUBLE if it is defined to be MPI_DATATYPE_NULL.