### PR TITLE
fix: segfault in sortgather_scatter if rank is not in sort group

### DIFF
--- a/src/dtcmp_sortv_sortgather_scatter.c
+++ b/src/dtcmp_sortv_sortgather_scatter.c
@@ -434,8 +434,10 @@ int dtcmp_sortv_scatter_tree(
   DTCMP_Memcpy(outbuf, remainder, keysat, buf, remainder, keysat);
 
   /* free our sort group */
-  lwgrp_comm_free(state->sort_lwgcomm);
-  dtcmp_free(&state->sort_lwgcomm);
+  if (state->sort_lwgcomm != NULL) {
+    lwgrp_comm_free(state->sort_lwgcomm);
+    dtcmp_free(&state->sort_lwgcomm);
+  }
 
   /* free memory */
   dtcmp_free(&state->buf);


### PR DESCRIPTION
Running sort tests detected a segfault due to a ``lwgrp_comm_free`` call on ranks that had no valid lwgrp communicator.  Only ranks in the sort group create the communicator, but all ranks were trying to free it.